### PR TITLE
fix(quickshell): allow escaping wallpaper picker with ESC key

### DIFF
--- a/config/sessions/hyprland/scripts/quickshell/wallpaper/WallpaperPicker.qml
+++ b/config/sessions/hyprland/scripts/quickshell/wallpaper/WallpaperPicker.qml
@@ -11,6 +11,12 @@ import "../"
 Item {
     id: window
     width: Screen.width
+    focus: true
+
+    Keys.onEscapePressed: {
+        Quickshell.execDetached(["bash", Quickshell.env("HOME") + "/.config/hypr/scripts/qs_manager.sh", "close"]);
+        event.accepted = true;
+    }
 
     Caching { id: paths }
 
@@ -884,7 +890,7 @@ Item {
         } 
     }
     
-    Shortcut { sequence: "Escape"; enabled: !window.isApplying; onActivated: { if (window.currentFilter === "Search") { window.currentFilter = "All"; } } }
+    Shortcut { sequence: "Escape"; enabled: !window.isApplying && window.currentFilter === "Search"; onActivated: { window.currentFilter = "All"; } }
     Shortcut { sequence: "Tab"; enabled: !window.isApplying; onActivated: window.cycleFilter(1) }
     Shortcut { sequence: "Backtab"; enabled: !window.isApplying; onActivated: window.cycleFilter(-1) }
 


### PR DESCRIPTION
This pull request fixes the Escape key behavior in the wallpaper picker. A window-wide Shortcut was intercepting the Escape key even when search was inactive, preventing the event from bubbling up to close the picker. Disabling the Shortcut when not in Search mode resolves the issue, allowing the Escape key to close the picker normally.